### PR TITLE
Ensure icache is properly synchronized when code is written to mem

### DIFF
--- a/arch/openrisc/Kconfig
+++ b/arch/openrisc/Kconfig
@@ -57,6 +57,12 @@ config WISHBONE_BUS_BIG_ENDIAN
 config GENERIC_CSUM
         def_bool y
 
+config DCACHE_WRITETHROUGH
+	bool "Have write through data caches"
+	default n
+	help
+	  Select this if your implementation features write through data caches.
+
 source "init/Kconfig"
 
 source "kernel/Kconfig.freezer"

--- a/arch/openrisc/include/asm/cacheflush.h
+++ b/arch/openrisc/include/asm/cacheflush.h
@@ -1,0 +1,84 @@
+/*
+ * OpenRISC Linux
+ *
+ * Linux architectural port borrowing liberally from similar works of
+ * others.  All original copyrights apply as per the original source
+ * declaration.
+ *
+ * OpenRISC implementation:
+ * Copyright (C) Jan Henrik Weinstock <jan.weinstock@rwth-aachen.de>
+ * et al.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef __ASM_CACHEFLUSH_H
+#define __ASM_CACHEFLUSH_H
+
+#include <linux/mm.h>
+
+/* 
+ * Helper function for flushing or invalidating entire pages from data
+ * and instruction caches. SMP needs a little extra work, since we need
+ * to flush the pages on all cpus.
+ */
+extern void local_dcache_page_flush(struct page *page);
+extern void local_icache_page_inv(struct page *page);
+
+/*
+ * For uniprocessor configurations, flush and invalidate functions just
+ * map to the local_XXX version. For SMP, we need to flush the caches on
+ * every cpu, which is done using the smp_XXX functions.
+ */
+#ifndef CONFIG_SMP
+#define dcache_page_flush(page)      local_dcache_page_flush(page)
+#define icache_page_inv(page)        local_icache_page_inv(page)
+#else  /* !CONFIG_SMP */
+#define dcache_page_flush(page)      smp_dcache_page_flush(page)
+#define icache_page_inv(page)        smp_icache_page_inv(page)
+extern void smp_dcache_page_flush(struct page *page);
+extern void smp_icache_page_inv(struct page *page);
+#endif /* CONFIG_SMP */
+
+/*
+ * Pages with this bit set need not be flushed/invalidated, since
+ * they have not changed since last flush. New pages start with
+ * PG_arch_1 not set and are therefore dirty by default.
+ */
+#define PG_dc_clean                  PG_arch_1
+
+#define ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE 1
+static inline void flush_dcache_page(struct page *page)
+{
+        clear_bit(PG_dc_clean, &page->flags);
+}
+
+/*
+ * Other interfaces are not required since we do not have virtually
+ * indexed or tagged caches. So we can use the default here.
+ */
+#define flush_cache_all()			do { } while (0)
+#define flush_cache_mm(mm)                      do { } while (0)
+#define flush_cache_dup_mm(mm)			do { } while (0)
+#define flush_cache_range(vma, start, end)	do { } while (0)
+#define flush_cache_page(vma, vmaddr, pfn)	do { } while (0)
+#define flush_dcache_mmap_lock(mapping)		do { } while (0)
+#define flush_dcache_mmap_unlock(mapping)	do { } while (0)
+#define flush_icache_range(start, end)		do { } while (0)
+#define flush_icache_page(vma,pg)		do { } while (0)
+#define flush_icache_user_range(vma,pg,adr,len)	do { } while (0)
+#define flush_cache_vmap(start, end)		do { } while (0)
+#define flush_cache_vunmap(start, end)		do { } while (0)
+
+#define copy_to_user_page(vma, page, vaddr, dst, src, len) \
+	do { \
+		memcpy(dst, src, len); \
+		flush_icache_user_range(vma, page, vaddr, len); \
+	} while (0)
+#define copy_from_user_page(vma, page, vaddr, dst, src, len) \
+	memcpy(dst, src, len)
+
+#endif /* __ASM_CACHEFLUSH_H */

--- a/arch/openrisc/include/asm/cacheflush.h
+++ b/arch/openrisc/include/asm/cacheflush.h
@@ -29,17 +29,16 @@ extern void local_dcache_page_flush(struct page *page);
 extern void local_icache_page_inv(struct page *page);
 
 /*
- * For uniprocessor configurations, flush and invalidate functions just
- * map to the local_XXX version. For SMP, we need to flush the caches on
- * every cpu, which is done using the smp_XXX functions.
+ * Data cache flushing always happen on the local cpu. Instruction cache
+ * invalidations need to be broadcasted to all other cpu in the system in
+ * case of SMP configurations.
  */
 #ifndef CONFIG_SMP
 #define dcache_page_flush(page)      local_dcache_page_flush(page)
 #define icache_page_inv(page)        local_icache_page_inv(page)
-#else  /* !CONFIG_SMP */
-#define dcache_page_flush(page)      smp_dcache_page_flush(page)
+#else  /* CONFIG_SMP */
+#define dcache_page_flush(page)      local_dcache_page_flush(page)
 #define icache_page_inv(page)        smp_icache_page_inv(page)
-extern void smp_dcache_page_flush(struct page *page);
 extern void smp_icache_page_inv(struct page *page);
 #endif /* CONFIG_SMP */
 
@@ -60,18 +59,18 @@ static inline void flush_dcache_page(struct page *page)
  * Other interfaces are not required since we do not have virtually
  * indexed or tagged caches. So we can use the default here.
  */
-#define flush_cache_all()			do { } while (0)
+#define flush_cache_all()                       do { } while (0)
 #define flush_cache_mm(mm)                      do { } while (0)
-#define flush_cache_dup_mm(mm)			do { } while (0)
-#define flush_cache_range(vma, start, end)	do { } while (0)
-#define flush_cache_page(vma, vmaddr, pfn)	do { } while (0)
-#define flush_dcache_mmap_lock(mapping)		do { } while (0)
-#define flush_dcache_mmap_unlock(mapping)	do { } while (0)
-#define flush_icache_range(start, end)		do { } while (0)
-#define flush_icache_page(vma,pg)		do { } while (0)
-#define flush_icache_user_range(vma,pg,adr,len)	do { } while (0)
-#define flush_cache_vmap(start, end)		do { } while (0)
-#define flush_cache_vunmap(start, end)		do { } while (0)
+#define flush_cache_dup_mm(mm)                  do { } while (0)
+#define flush_cache_range(vma, start, end)      do { } while (0)
+#define flush_cache_page(vma, vmaddr, pfn)      do { } while (0)
+#define flush_dcache_mmap_lock(mapping)         do { } while (0)
+#define flush_dcache_mmap_unlock(mapping)       do { } while (0)
+#define flush_icache_range(start, end)          do { } while (0)
+#define flush_icache_page(vma,pg)               do { } while (0)
+#define flush_icache_user_range(vma,pg,adr,len) do { } while (0)
+#define flush_cache_vmap(start, end)            do { } while (0)
+#define flush_cache_vunmap(start, end)          do { } while (0)
 
 #define copy_to_user_page(vma, page, vaddr, dst, src, len) \
 	do { \

--- a/arch/openrisc/include/asm/pgtable.h
+++ b/arch/openrisc/include/asm/pgtable.h
@@ -413,15 +413,19 @@ static inline void pmd_set(pmd_t *pmdp, pte_t *ptep)
 
 extern pgd_t swapper_pg_dir[PTRS_PER_PGD]; /* defined in head.S */
 
-/*
- * or32 doesn't have any external MMU info: the kernel page
- * tables contain all the necessary information.
- *
- * Actually I am not sure on what this could be used for.
- */
+static inline void update_tlb(struct vm_area_struct *vma,
+	unsigned long address, pte_t *pte)
+{
+}
+
+extern void update_cache(struct vm_area_struct *vma,
+	unsigned long address, pte_t *pte);
+
 static inline void update_mmu_cache(struct vm_area_struct *vma,
 	unsigned long address, pte_t *pte)
 {
+	update_tlb(vma, address, pte);
+	update_cache(vma, address, pte);
 }
 
 /* __PHX__ FIXME, SWAP, this probably doesn't work */

--- a/arch/openrisc/kernel/smp.c
+++ b/arch/openrisc/kernel/smp.c
@@ -225,19 +225,7 @@ void flush_tlb_range(struct vm_area_struct *vma,
 	on_each_cpu(ipi_flush_tlb_all, NULL, 1);
 }
 
-/* Cache flush/invalidate operations - performed on each cpu */
-static void ipi_dcache_page_flush(void *arg)
-{
-	struct page *page = arg;
-	local_dcache_page_flush(page);
-}
-
-void smp_dcache_page_flush(struct page *page)
-{
-	on_each_cpu(ipi_dcache_page_flush, page, 1);
-}
-EXPORT_SYMBOL(smp_dcache_page_flush);
-
+/* Instruction cache invalidate - performed on each cpu */
 static void ipi_icache_page_inv(void *arg)
 {
 	struct page *page = arg;

--- a/arch/openrisc/kernel/smp.c
+++ b/arch/openrisc/kernel/smp.c
@@ -16,6 +16,7 @@
 #include <asm/cpuinfo.h>
 #include <asm/mmu_context.h>
 #include <asm/tlbflush.h>
+#include <asm/cacheflush.h>
 
 volatile unsigned long secondary_release = -1;
 struct thread_info *secondary_thread_info;
@@ -223,3 +224,28 @@ void flush_tlb_range(struct vm_area_struct *vma,
 {
 	on_each_cpu(ipi_flush_tlb_all, NULL, 1);
 }
+
+/* Cache flush/invalidate operations - performed on each cpu */
+static void ipi_dcache_page_flush(void *arg)
+{
+	struct page *page = arg;
+	local_dcache_page_flush(page);
+}
+
+void smp_dcache_page_flush(struct page *page)
+{
+	on_each_cpu(ipi_dcache_page_flush, page, 1);
+}
+EXPORT_SYMBOL(smp_dcache_page_flush);
+
+static void ipi_icache_page_inv(void *arg)
+{
+	struct page *page = arg;
+	local_icache_page_inv(page);
+}
+
+void smp_icache_page_inv(struct page *page)
+{
+	on_each_cpu(ipi_icache_page_inv, page, 1);
+}
+EXPORT_SYMBOL(smp_icache_page_inv);

--- a/arch/openrisc/mm/Makefile
+++ b/arch/openrisc/mm/Makefile
@@ -2,4 +2,4 @@
 # Makefile for the linux openrisc-specific parts of the memory manager.
 #
 
-obj-y	:= fault.o tlb.o init.o ioremap.o
+obj-y	:= fault.o cache.o tlb.o init.o ioremap.o

--- a/arch/openrisc/mm/cache.c
+++ b/arch/openrisc/mm/cache.c
@@ -1,0 +1,63 @@
+/*
+ * OpenRISC cache.c
+ *
+ * Linux architectural port borrowing liberally from similar works of
+ * others.  All original copyrights apply as per the original source
+ * declaration.
+ *
+ * Modifications for the OpenRISC architecture:
+ * Copyright (C) 2015 Jan Henrik Weinstock <jan.weinstock@rwth-aachen.de>
+ *
+ *      This program is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU General Public License
+ *      as published by the Free Software Foundation; either version
+ *      2 of the License, or (at your option) any later version.
+ */
+
+#include <asm/spr.h>
+#include <asm/spr_defs.h>
+#include <asm/cache.h>
+#include <asm/cacheflush.h>
+#include <asm/tlbflush.h>
+
+static void cache_loop(struct page *page, const unsigned int reg)
+{
+	unsigned long paddr = page_to_pfn(page) << PAGE_SHIFT;
+	unsigned long line = paddr & ~(L1_CACHE_BYTES - 1);
+	while (line < paddr + PAGE_SIZE) {
+		mtspr(reg, line);
+		line += L1_CACHE_BYTES;
+	}
+}
+
+void local_dcache_page_flush(struct page *page)
+{
+	cache_loop(page, SPR_DCBFR);
+}
+EXPORT_SYMBOL(local_dcache_page_flush);
+
+void local_icache_page_inv(struct page *page)
+{
+	cache_loop(page, SPR_ICBIR);
+}
+EXPORT_SYMBOL(local_icache_page_inv);
+
+void update_cache(struct vm_area_struct *vma, unsigned long address,
+	pte_t *pte)
+{
+	unsigned long pfn = pte_val(*pte) >> PAGE_SHIFT;
+	struct page *page = pfn_to_page(pfn);
+	int dirty = !test_and_set_bit(PG_dc_clean, &page->flags);
+
+	/* 
+	 * Since icaches do not snoop for updated data on OpenRISC, we
+	 * must write back and invalidate any dirty pages manually. We
+	 * can skip data pages, since they will not end up in icaches.
+	 */
+	if ((vma->vm_flags & VM_EXEC) && dirty) {
+		if (!IS_ENABLED(CONFIG_OPENRISC_DCACHE_WRITETHROUGH))
+			dcache_page_flush(page);
+		icache_page_inv(page);
+	}
+}
+

--- a/arch/openrisc/mm/cache.c
+++ b/arch/openrisc/mm/cache.c
@@ -55,7 +55,7 @@ void update_cache(struct vm_area_struct *vma, unsigned long address,
 	 * can skip data pages, since they will not end up in icaches.
 	 */
 	if ((vma->vm_flags & VM_EXEC) && dirty) {
-		if (!IS_ENABLED(CONFIG_OPENRISC_DCACHE_WRITETHROUGH))
+		if (!IS_ENABLED(CONFIG_DCACHE_WRITETHROUGH))
 			dcache_page_flush(page);
 		icache_page_inv(page);
 	}

--- a/arch/openrisc/mm/cache.c
+++ b/arch/openrisc/mm/cache.c
@@ -54,10 +54,7 @@ void update_cache(struct vm_area_struct *vma, unsigned long address,
 	 * must write back and invalidate any dirty pages manually. We
 	 * can skip data pages, since they will not end up in icaches.
 	 */
-	if ((vma->vm_flags & VM_EXEC) && dirty) {
-		if (!IS_ENABLED(CONFIG_DCACHE_WRITETHROUGH))
-			dcache_page_flush(page);
-		icache_page_inv(page);
-	}
+	if ((vma->vm_flags & VM_EXEC) && dirty)
+		sync_icache_dcache(page);
 }
 


### PR DESCRIPTION
OpenRISC icaches are not synchronized. We need to invalidate icaches when Linux loads a new executable page to a page frame.
